### PR TITLE
StoreEntity에 위경도 데이터가 추가되도록 수정

### DIFF
--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/dto/StoreDto.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/dto/StoreDto.kt
@@ -12,4 +12,6 @@ data class Document(
     @SerializedName("phone") val phone: String?,
     @SerializedName("place_name") val placeName: String?,
     @SerializedName("road_address_name") val roadAddressName: String?,
+    @SerializedName("x") val x: String?, //longitude
+    @SerializedName("y") val y: String?  //latitude
 )

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/mapper/StoreMapper.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/mapper/StoreMapper.kt
@@ -12,6 +12,8 @@ object StoreMapper {
                 categoryGroupName = it.categoryGroupName,
                 address = it.roadAddressName,
                 phone = it.phone,
+                lat = it.y,
+                lng = it.x
             )
         }
         return resultForStore

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/domain/entity/StoreEntity.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/domain/entity/StoreEntity.kt
@@ -6,4 +6,6 @@ data class StoreEntity (
     val categoryGroupName: String?,
     val address: String?,
     val phone: String?,
+    val lat: String?,
+    val lng: String?,
 )


### PR DESCRIPTION
resolved: #68 

---

storeEntity에 위도, 경도 데이터가 추가되어 있지 않아 spot에서 사용할 수 있도록 추가하였습니다.

kakao api에서 위경도 값을 string으로 주고 있습니다.
double 타입이 필요할 경우 적절히 변환하여 사용하시면 될 것 같습니다.

