### PR TITLE
스탬프 조건 확인 및 저장 기능 구현

### DIFF
--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/app/di/UseCaseModule.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/app/di/UseCaseModule.kt
@@ -1,5 +1,7 @@
 package com.nbcfinalteam2.ddaraogae.app.di
 
+import com.nbcfinalteam2.ddaraogae.domain.usecase.CheckStampConditionUseCase
+import com.nbcfinalteam2.ddaraogae.domain.usecase.CheckStampConditionUseCaseImpl
 import com.nbcfinalteam2.ddaraogae.domain.usecase.DeleteAccountUseCase
 import com.nbcfinalteam2.ddaraogae.domain.usecase.DeleteAccountUseCaseImpl
 import com.nbcfinalteam2.ddaraogae.domain.usecase.DeleteDogUseCase
@@ -148,4 +150,9 @@ abstract class UseCaseModule {
     abstract fun bindSendVerificationEmailUseCase(
         sendVerificationEmailUseCaseImpl: SendVerificationEmailUseCaseImpl
     ): SendVerificationEmailUseCase
+
+    @Binds
+    abstract fun bindCheckStampConditionUseCase(
+        checkStampConditionUseCaseImpl: CheckStampConditionUseCaseImpl
+    ): CheckStampConditionUseCase
 }

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/DataUtil.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/DataUtil.kt
@@ -34,7 +34,7 @@ object DataUtil {
                 curMaxNum = 1
             }
         }
-
+        totalMaxNum = max(curMaxNum, totalMaxNum)
         return totalMaxNum
     }
 }
@@ -69,6 +69,7 @@ fun Date.getDayStartAndEnd(): Pair<Date, Date> {
 fun Date.getWeekStartAndEnd(): Pair<Date, Date> {
     val cal = Calendar.getInstance()
     cal.time = this
+    cal.firstDayOfWeek = Calendar.MONDAY
 
     val mondayStart = cal.apply {
         set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/DataUtil.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/DataUtil.kt
@@ -1,0 +1,90 @@
+package com.nbcfinalteam2.ddaraogae.data.datasource.remote.firebase
+
+import com.nbcfinalteam2.ddaraogae.data.dto.WalkingDto
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Calendar
+import java.util.Date
+import kotlin.math.max
+
+object DataUtil {
+
+    // 기준일 동안 진행된 산책 데이터의 거리 총합
+    fun getTotalDistanceInADay(date: Date, walkingList: List<WalkingDto>): Double {
+        val (startDate, endDate) = date.getDayStartAndEnd()
+
+        return walkingList.filter { it.startDateTime!! in startDate..endDate }.sumOf { it.distance!! }
+    }
+
+    // 주어진 산책 데이터 리스트에서 연속된 최대 산책 일수 계산
+    fun getLongestConsecutiveWalkingDays(walkingList: List<WalkingDto>): Int {
+        val convertedList = walkingList.map { it.startDateTime!!.toLocalDate() }
+        if(convertedList.isEmpty()) return 0
+        var totalMaxNum = 1
+        var curMaxNum = 1
+        var prevDate = convertedList.first()
+
+        for(localDate in convertedList) {
+            if(localDate.isEqual(prevDate.plusDays(1))) {
+                prevDate = localDate
+                curMaxNum++
+            }else if(localDate.isAfter(prevDate)) {
+                prevDate = localDate
+                totalMaxNum = max(curMaxNum, totalMaxNum)
+                curMaxNum = 1
+            }
+        }
+
+        return totalMaxNum
+    }
+}
+
+fun Date.toLocalDate(): LocalDate {
+    return this.toInstant()
+        .atZone(ZoneId.systemDefault())
+        .toLocalDate()
+}
+
+fun Date.getDayStartAndEnd(): Pair<Date, Date> {
+    val cal = Calendar.getInstance()
+    cal.time = this
+
+    val startDate = cal.apply {
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }.time
+
+    val endDate = cal.apply {
+        set(Calendar.HOUR_OF_DAY, 23)
+        set(Calendar.MINUTE, 59)
+        set(Calendar.SECOND, 59)
+        set(Calendar.MILLISECOND, 999)
+    }.time
+
+    return startDate to endDate
+}
+
+fun Date.getWeekStartAndEnd(date: Date): Pair<Date, Date> {
+    val cal = Calendar.getInstance()
+    cal.time = date
+
+    val mondayStart = cal.apply {
+        set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }.time
+
+    val sundayEnd = cal.apply {
+        set(Calendar.DAY_OF_WEEK, Calendar.SUNDAY)
+        set(Calendar.HOUR_OF_DAY, 23)
+        set(Calendar.MINUTE, 59)
+        set(Calendar.SECOND, 59)
+        set(Calendar.MILLISECOND, 999)
+    }.time
+
+    return mondayStart to sundayEnd
+}

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/DataUtil.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/DataUtil.kt
@@ -66,9 +66,9 @@ fun Date.getDayStartAndEnd(): Pair<Date, Date> {
     return startDate to endDate
 }
 
-fun Date.getWeekStartAndEnd(date: Date): Pair<Date, Date> {
+fun Date.getWeekStartAndEnd(): Pair<Date, Date> {
     val cal = Calendar.getInstance()
-    cal.time = date
+    cal.time = this
 
     val mondayStart = cal.apply {
         set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/FirebaseDataSource.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/FirebaseDataSource.kt
@@ -17,7 +17,7 @@ interface FirebaseDataSource {
     //stamp
     suspend fun getStampNumByDogIdAndPeriod(dogId: String, start: Date, end: Date): Int
     suspend fun insertStamp(stampDto: StampDto)
-    suspend fun checkStampCondition(dogId: String, date: Date): List<StampDto>
+    suspend fun checkStampCondition(dogId: String, date: Date): List<Pair<String, StampDto>>
 
     //walking
     suspend fun getWalkingListByDogIdAndPeriod(dogId: String, start: Date, end: Date): List<Pair<String, WalkingDto>>

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/FirebaseDataSource.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/FirebaseDataSource.kt
@@ -17,6 +17,7 @@ interface FirebaseDataSource {
     //stamp
     suspend fun getStampNumByDogIdAndPeriod(dogId: String, start: Date, end: Date): Int
     suspend fun insertStamp(stampDto: StampDto)
+    suspend fun checkStampCondition(dogId: String, date: Date): List<StampDto>
 
     //walking
     suspend fun getWalkingListByDogIdAndPeriod(dogId: String, start: Date, end: Date): List<Pair<String, WalkingDto>>

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
@@ -7,9 +7,6 @@ import com.nbcfinalteam2.ddaraogae.data.dto.DogDto
 import com.nbcfinalteam2.ddaraogae.data.dto.StampDto
 import com.nbcfinalteam2.ddaraogae.data.dto.WalkingDto
 import kotlinx.coroutines.tasks.await
-import java.time.LocalDate
-import java.time.ZoneId
-import java.util.Calendar
 import java.util.Date
 import javax.inject.Inject
 
@@ -189,6 +186,10 @@ class FirebaseDataSourceImpl @Inject constructor(
                     StampInfo.STAMP_8.toStampDto(date)
                 )
             }
+        }
+
+        for(stamp in getStampList) {
+            insertStamp(stamp)
         }
 
         return getStampList

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
@@ -2,10 +2,14 @@ package com.nbcfinalteam2.ddaraogae.data.datasource.remote.firebase
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
 import com.nbcfinalteam2.ddaraogae.data.dto.DogDto
 import com.nbcfinalteam2.ddaraogae.data.dto.StampDto
 import com.nbcfinalteam2.ddaraogae.data.dto.WalkingDto
 import kotlinx.coroutines.tasks.await
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Calendar
 import java.util.Date
 import javax.inject.Inject
 
@@ -77,6 +81,117 @@ class FirebaseDataSourceImpl @Inject constructor(
         firebaseFs.collection(PATH_USERDATA).document(uid)
             .collection(PATH_STAMPS)
             .add(stampDto).await()
+    }
+
+    /**
+     * stamp number
+     * #0 : UNKNOWN
+     * #1 : 1.5km per day
+     * #2~4 : consecutive 3/5/7days
+     * #5 : 7 walking in a week
+     * #6~8 : total distance 10km+/15km+/20km+
+     */
+    override suspend fun checkStampCondition(dogId: String, date: Date): List<StampDto> {
+        val uid = getUserUid()
+
+        val (mondayStart, sundayEnd) = date.getWeekStartAndEnd(date)
+
+        val queriedWalkingList = firebaseFs.collection(PATH_USERDATA).document(uid)
+            .collection(PATH_WALKING)
+            .whereEqualTo(FIELD_DOG_ID, dogId)
+            .whereGreaterThanOrEqualTo(FIELD_START_DATETIME, mondayStart)
+            .whereLessThanOrEqualTo(FIELD_START_DATETIME, sundayEnd)
+            .orderBy(FIELD_START_DATETIME, Query.Direction.ASCENDING)
+            .get().await()
+            .map {
+                it.toObject(WalkingDto::class.java)
+            }
+
+        val queriedStampList = List<MutableList<StampDto>>(9) { mutableListOf() }
+
+        firebaseFs.collection(PATH_USERDATA).document(uid)
+            .collection(PATH_STAMPS)
+            .whereEqualTo(FIELD_DOG_ID, dogId)
+            .whereEqualTo(FIELD_GET_DATETIME, mondayStart)
+            .whereEqualTo(FIELD_GET_DATETIME, sundayEnd)
+            .get().await()
+            .forEach {
+                val stamp = it.toObject(StampDto::class.java)
+                queriedStampList[stamp.stampNum?:0].add(stamp)
+            }
+        val getStampList = mutableListOf<StampDto>()
+
+        //#1
+        if(queriedStampList[1].none { it.getDateTime?.toLocalDate()?.isEqual(date.toLocalDate()) == true }) {
+            if(DataUtil.getTotalDistanceInADay(date, queriedWalkingList) >= 1.5) {
+                getStampList.add(
+                    StampInfo.STAMP_1.toStampDto(date)
+                )
+            }
+        }
+
+        //#2~4
+        var passFlag = true
+        for(i in 2..4) {
+            if(queriedStampList[i].isEmpty()) {
+                passFlag = false
+                break
+            }
+        }
+        if(!passFlag) {
+            val longestConsecutiveDays = DataUtil.getLongestConsecutiveWalkingDays(queriedWalkingList)
+            if(queriedStampList[2].isEmpty() && longestConsecutiveDays>=3) {
+                getStampList.add(
+                    StampInfo.STAMP_2.toStampDto(date)
+                )
+            }
+            if(queriedStampList[3].isEmpty() && longestConsecutiveDays>=5) {
+                getStampList.add(
+                    StampInfo.STAMP_3.toStampDto(date)
+                )
+            }
+            if(queriedStampList[4].isEmpty() && longestConsecutiveDays>=7) {
+                getStampList.add(
+                    StampInfo.STAMP_4.toStampDto(date)
+                )
+            }
+        }
+
+        //#5
+        if(queriedStampList[5].isEmpty() && queriedWalkingList.size>=7) {
+            getStampList.add(
+                StampInfo.STAMP_5.toStampDto(date)
+            )
+        }
+
+        //#6~8
+        passFlag = true
+        for(i in 6..8) {
+            if(queriedStampList[i].isEmpty()) {
+                passFlag = false
+                break
+            }
+        }
+        if(!passFlag) {
+            val totalDistance = queriedWalkingList.sumOf { it.distance?:0.0 }
+            if(queriedStampList[6].isEmpty() && totalDistance>=10) {
+                getStampList.add(
+                    StampInfo.STAMP_6.toStampDto(date)
+                )
+            }
+            if(queriedStampList[7].isEmpty() && totalDistance>=15) {
+                getStampList.add(
+                    StampInfo.STAMP_7.toStampDto(date)
+                )
+            }
+            if(queriedStampList[8].isEmpty() && totalDistance>=20) {
+                getStampList.add(
+                    StampInfo.STAMP_8.toStampDto(date)
+                )
+            }
+        }
+
+        return getStampList
     }
 
     override suspend fun getWalkingListByDogIdAndPeriod(

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
@@ -108,14 +108,14 @@ class FirebaseDataSourceImpl @Inject constructor(
 
         firebaseFs.collection(PATH_USERDATA).document(uid)
             .collection(PATH_STAMPS)
-            .whereEqualTo(FIELD_DOG_ID, dogId)
-            .whereEqualTo(FIELD_GET_DATETIME, mondayStart)
-            .whereEqualTo(FIELD_GET_DATETIME, sundayEnd)
+            .whereGreaterThanOrEqualTo(FIELD_GET_DATETIME, mondayStart)
+            .whereLessThanOrEqualTo(FIELD_GET_DATETIME, sundayEnd)
             .get().await()
             .forEach {
                 val stamp = it.toObject(StampDto::class.java)
                 queriedStampList[stamp.stampNum?:0].add(stamp)
             }
+
         val getStampList = mutableListOf<StampDto>()
         val resultList = mutableListOf<Pair<String, StampDto>>()
 

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/FirebaseDataSourceImpl.kt
@@ -91,7 +91,7 @@ class FirebaseDataSourceImpl @Inject constructor(
     override suspend fun checkStampCondition(dogId: String, date: Date): List<StampDto> {
         val uid = getUserUid()
 
-        val (mondayStart, sundayEnd) = date.getWeekStartAndEnd(date)
+        val (mondayStart, sundayEnd) = date.getWeekStartAndEnd()
 
         val queriedWalkingList = firebaseFs.collection(PATH_USERDATA).document(uid)
             .collection(PATH_WALKING)

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/StampInfo.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/datasource/remote/firebase/StampInfo.kt
@@ -1,0 +1,26 @@
+package com.nbcfinalteam2.ddaraogae.data.datasource.remote.firebase
+
+import com.nbcfinalteam2.ddaraogae.data.dto.StampDto
+import java.util.Date
+
+data class StampInfo(
+    val num: Int,
+    val title: String
+) {
+    fun toStampDto(getDateTime: Date) = StampDto(
+        stampNum = num,
+        getDateTime = getDateTime,
+        name = title
+    )
+    companion object {
+        val STAMP_0 = StampInfo(0, "UNKNOWN")
+        val STAMP_1 = StampInfo(1, "오늘의 산책 완료")
+        val STAMP_2 = StampInfo(2, "3일 연속 산책")
+        val STAMP_3 = StampInfo(3, "오늘의 산책 완료")
+        val STAMP_4 = StampInfo(4, "오늘의 산책 완료")
+        val STAMP_5 = StampInfo(5, "다다익선")
+        val STAMP_6 = StampInfo(6, "단거리 마라토너")
+        val STAMP_7 = StampInfo(7, "중거리 마라토너")
+        val STAMP_8 = StampInfo(8, "장거리 마라토너")
+    }
+}

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/mapper/FirebaseMapper.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/mapper/FirebaseMapper.kt
@@ -8,7 +8,6 @@ import com.nbcfinalteam2.ddaraogae.data.dto.WalkingDto
 import com.nbcfinalteam2.ddaraogae.domain.entity.DogEntity
 import com.nbcfinalteam2.ddaraogae.domain.entity.StampEntity
 import com.nbcfinalteam2.ddaraogae.domain.entity.WalkingEntity
-import java.util.Date
 
 object FirebaseMapper {
     fun DogDto.toEntity(id: String) = DogEntity(
@@ -34,13 +33,13 @@ object FirebaseMapper {
         id = id,
         stampNum = stampNum,
         getDateTime = getDateTime,
-        name = name
+        name = name,
     )
 
     fun StampEntity.toDto() = StampDto(
         stampNum = stampNum,
         getDateTime = getDateTime,
-        name = name
+        name = name,
     )
 
     fun WalkingDto.toEntity(id: String) = WalkingEntity(

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/repository/StampRepositoryImpl.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/data/repository/StampRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.nbcfinalteam2.ddaraogae.data.repository
 
 import com.nbcfinalteam2.ddaraogae.data.datasource.remote.firebase.FirebaseDataSource
 import com.nbcfinalteam2.ddaraogae.data.mapper.FirebaseMapper.toDto
+import com.nbcfinalteam2.ddaraogae.data.mapper.FirebaseMapper.toEntity
 import com.nbcfinalteam2.ddaraogae.domain.entity.StampEntity
 import com.nbcfinalteam2.ddaraogae.domain.repository.StampRepository
 import java.util.Date
@@ -16,5 +17,11 @@ class StampRepositoryImpl @Inject constructor(
 
     override suspend fun insertStamp(stampEntity: StampEntity) {
         firebaseDateSource.insertStamp(stampEntity.toDto())
+    }
+
+    override suspend fun checkStampCondition(dogId: String, date: Date): List<StampEntity> {
+        return firebaseDateSource.checkStampCondition(dogId, date).map {
+            it.second.toEntity(it.first)
+        }
     }
 }

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/domain/entity/StampEntity.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/domain/entity/StampEntity.kt
@@ -6,5 +6,5 @@ data class StampEntity(
     val id: String?,
     val stampNum: Int?,
     val getDateTime: Date?,
-    val name: String?
+    val name: String?,
 )

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/domain/repository/StampRepository.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/domain/repository/StampRepository.kt
@@ -6,4 +6,5 @@ import java.util.Date
 interface StampRepository {
     suspend fun getStampNumByDogIdAndPeriod(dogId: String, start: Date, end: Date): Int
     suspend fun insertStamp(stampEntity: StampEntity)
+    suspend fun checkStampCondition(dogId: String, date: Date): List<StampEntity>
 }

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/domain/usecase/CheckStampConditionUseCase.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/domain/usecase/CheckStampConditionUseCase.kt
@@ -1,0 +1,8 @@
+package com.nbcfinalteam2.ddaraogae.domain.usecase
+
+import com.nbcfinalteam2.ddaraogae.domain.entity.StampEntity
+import java.util.Date
+
+interface CheckStampConditionUseCase {
+    suspend operator fun invoke(dogId: String, date: Date): List<StampEntity>
+}

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/domain/usecase/CheckStampConditionUseCaseImpl.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/domain/usecase/CheckStampConditionUseCaseImpl.kt
@@ -1,0 +1,11 @@
+package com.nbcfinalteam2.ddaraogae.domain.usecase
+
+import com.nbcfinalteam2.ddaraogae.domain.repository.StampRepository
+import java.util.Date
+import javax.inject.Inject
+
+class CheckStampConditionUseCaseImpl @Inject constructor(
+    private val stampRepository: StampRepository
+): CheckStampConditionUseCase {
+    override suspend fun invoke(dogId: String, date: Date) = stampRepository.checkStampCondition(dogId, date)
+}


### PR DESCRIPTION
1. 조건에 따라 획득 가능한 스탬프 리턴 및 저장 확인(이미 획득한 스탬프는 제외하고 계산하는 것도 정상 작동)
2. 세심하게 모든 조건에서 테스트 해본 것은 아님

해결해야 할 문제
1. 반려견 여러마리 산책시켰을 때, 산책 데이터가 반려견마다 생성되는데, 이를 모두 들고 와 통계를 내니 스탬프 획득이 너무 쉬워짐.
그렇다고 산책 데이터에 반려견 정보가 담기지 않으면 반려견 별로 산책 이력을 제공할 수 없음.
한 산책 데이터 내에 반려견 ID 여러개를 넣는 형태는, 나중에 파이어베이스 상에서 반려견 ID로 산책 데이터를 필터링하는데 치명적이므로 되도록 피하고 싶음(제1정규화 원칙에도 위배됨).

resolved: #66 