### PR TITLE
지도 크기 유동적으로 변하도록 변경

### DIFF
--- a/app/src/main/res/layout/fragment_walk.xml
+++ b/app/src/main/res/layout/fragment_walk.xml
@@ -52,12 +52,10 @@
         android:id="@+id/fragment_walk"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/v_walk_ui_background"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.constraintlayout.widget.Group
         android:id="@+id/gr_walk_prev"


### PR DESCRIPTION
- map fragment 들어갈 View constraint 기준 변경

resolved: #111


https://github.com/nbc-final-team2/ddaraogae/assets/104819764/6e3842ca-1287-4b64-9861-c336fffcacf0

이렇게 처리하니, 대신 산책 중 인터페이스가 사라질 때 렌더링 속도 때문에 검은 공간이 노출되는 문제가 생기네요
Map 상에서 현재 위치로 향하는 버튼의 위치를 바꾸는 방법은 딱히 안 보이고..
이렇게라도 처리하는게 맞을 지 모르겠습니다, 실제 앱 동작에서는 결과 화면으로 전환될테니 티가 많이 안 날 것 같기도 하고요