### PR TITLE
복수의 반려견 동반 산책 시, 중복된 스탬프 획득 버그 수정

### DIFF
--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/walk/FinishActivity.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/walk/FinishActivity.kt
@@ -265,14 +265,13 @@ class FinishActivity : FragmentActivity() {
         if (::naverMap.isInitialized) {
             naverMap.takeSnapshot {
                 val mapImage = bitmapToByteArray(it)
-                for(dog in walkingDogs) {
-                    viewModel.insertWalkingData(
-                        walk = walkingUiModel.copy(
+                viewModel.insertWalkingData(
+                    walkingDogs.map { dog ->
+                        walkingUiModel.copy(
                             dogId = dog.id
-                        ),
-                        image = mapImage!!
-                    )
-                }
+                        )
+                    } to mapImage!!
+                )
             }
         }
     }

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/walk/FinishViewModel.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/walk/FinishViewModel.kt
@@ -39,10 +39,10 @@ class FinishViewModel @Inject constructor(
     val finishUiState: StateFlow<FinishUiState> = _finishUiState.asStateFlow()
 
 
-    fun insertWalkingData(walk: WalkingInfo, image: ByteArray) {
+    fun insertWalkingData(walkDataSet: Pair<List<WalkingInfo>, ByteArray>) {
         _finishUiState.value = FinishUiState(true)
         viewModelScope.launch {
-            val walkingData = walk.let {
+            val walkingDataList = walkDataSet.first.map {
                 WalkingEntity(
                     it.id,
                     it.dogId,
@@ -53,9 +53,12 @@ class FinishViewModel @Inject constructor(
                     it.walkingImage
                 )
             }
+            val image = walkDataSet.second
 
             try {
-                insertWalkingDataUseCase.invoke(walkingData, image)
+                for(walkingData in walkingDataList) {
+                    insertWalkingDataUseCase.invoke(walkingData, image)
+                }
                 _insertEvent.emit(DefaultEvent.Success)
             } catch (e: Exception) {
                 _insertEvent.emit(DefaultEvent.Failure(R.string.msg_walk_upload_fail))


### PR DESCRIPTION
반려견 마다 ViewModel의 메소드를 호출하는 것이 아닌, 반려견 전체를 넘겨서 업로드 하는 ViewModel 메소드 내에서 반복문 처리하도록 변경

issue: #192