### PR TITLE
firebase crashlytics 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.nbcfinalteam2.ddaraogae"
         minSdk = 28
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -40,8 +40,8 @@ android {
     buildTypes {
         getByName("release") {
             signingConfig = signingConfigs.getByName("release")
-            isMinifyEnabled = false
-            isDebuggable = true
+            isMinifyEnabled = true //릴리즈용으로 번들을 추출할 때에는 false로 변경해야함
+            isDebuggable = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("kotlin-parcelize")
     id("kotlin-kapt")
     id("com.google.dagger.hilt.android")
+    alias(libs.plugins.firebaseCrachlytics)
 }
 
 android {
@@ -96,6 +97,7 @@ dependencies {
     //firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)
+    implementation(libs.firebase.crashlytics)
     implementation(libs.firebase.database.ktx)
     implementation(libs.firebase.firestore)
     implementation(libs.firebase.storage)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid) apply false
     alias(libs.plugins.googleGmsGoogleService) apply false
     alias(libs.plugins.googleDaggerHiltAndroid) apply false
+    alias(libs.plugins.firebaseCrachlytics) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ mockito = "3.11.2"
 kotlinx-coroutines = "1.5.0"
 mockwebserver = "4.9.1"
 googleService = "4.4.2"
+crashlytics = "2.9.9"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -35,6 +36,7 @@ androidx-navigation-testing = { module = "androidx.navigation:navigation-testing
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationCompose" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 firebase-database-ktx = { group = "com.google.firebase", name = "firebase-database-ktx" }
 firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx" }
 firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore" }
@@ -67,4 +69,5 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 googleGmsGoogleService = { id = "com.google.gms.google-services", version.ref = "googleService" }
 googleDaggerHiltAndroid = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+firebaseCrachlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlytics" }
 


### PR DESCRIPTION
resolved: #211 

---

크래쉬 발생 시 아래 이미지와 같은 리포트가 도착하고, 상세 내용을 확인할 수 있습니다.

<img width="1178" alt="image" src="https://github.com/nbc-final-team2/ddaraogae/assets/128209823/92388d3e-d588-4151-b1df-5e2149510df9">
<img width="1191" alt="image" src="https://github.com/nbc-final-team2/ddaraogae/assets/128209823/2d6a119f-69c6-4385-bd4a-d8078289533f">

---

firebase 상에서 확인하는법

firebase -> 실행 -> crashlytics

![image](https://github.com/nbc-final-team2/ddaraogae/assets/128209823/d48f791c-b6e6-495f-a97d-0bc8ae608990)

