### PR TITLE
fragment 내의 flow collect하는 코루틴 lifecycle 수정

### DIFF
--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/home/HomeFragment.kt
@@ -101,7 +101,7 @@ class HomeFragment : Fragment() {
 
     private fun initViewModels() {
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             homeViewModel.dogListState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest { dogList ->
                     dogProfileAdapter.submitList(dogList)
@@ -109,7 +109,7 @@ class HomeFragment : Fragment() {
                 }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             homeViewModel.selectDogState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest { dogData ->
                     if (dogData != null) {
@@ -119,7 +119,7 @@ class HomeFragment : Fragment() {
                 }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             homeViewModel.walkListState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest { walkData ->
                     if (walkData.isEmpty()) {
@@ -132,21 +132,21 @@ class HomeFragment : Fragment() {
                 }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             homeViewModel.weatherInfoState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest { weatherInfo ->
                     updateWeatherUI(weatherInfo)
                 }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             itemChangedEventBus.itemChangedEvent.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest {
                     homeViewModel.refreshDogList()
                 }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             homeViewModel.stampProgressState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest { progress ->
                     binding.progressbarWalkStampRate.progress = progress
@@ -154,7 +154,7 @@ class HomeFragment : Fragment() {
                 }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             homeViewModel.loadDogEvent.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest { event ->
                     when (event) {
@@ -164,7 +164,7 @@ class HomeFragment : Fragment() {
                 }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             homeViewModel.updateDogEvent.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest { event ->
                     when (event) {
@@ -174,7 +174,7 @@ class HomeFragment : Fragment() {
                 }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             homeViewModel.loadWalkDataEvent.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest { event ->
                     when (event) {
@@ -184,7 +184,7 @@ class HomeFragment : Fragment() {
                 }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             homeViewModel.loadWeatherEvent.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest { event ->
                     when (event) {
@@ -200,7 +200,7 @@ class HomeFragment : Fragment() {
                 }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             homeViewModel.loadStampEvent.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest { event ->
                     when (event) {
@@ -210,7 +210,7 @@ class HomeFragment : Fragment() {
                 }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             itemChangedEventBus.stampChangedEvent.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest {
                     homeViewModel.loadStampProgress()

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/mypage/MypageFragment.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/mypage/MypageFragment.kt
@@ -76,7 +76,7 @@ class MypageFragment : Fragment() {
 
     private fun initViewModel() {
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             viewModel.restartEvent.flowWithLifecycle(viewLifecycleOwner.lifecycle).collectLatest {
                 when(it) {
                     is DefaultEvent.Failure -> {}
@@ -91,7 +91,7 @@ class MypageFragment : Fragment() {
             }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             viewModel.mypageEvent.flowWithLifecycle(viewLifecycleOwner.lifecycle).collectLatest { event->
                 when(event) {
                     is DefaultEvent.Failure -> ToastMaker.make(requireContext(), event.msg)
@@ -100,7 +100,7 @@ class MypageFragment : Fragment() {
             }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             viewModel.mypageUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle).collectLatest { state->
                 if (state.isLoading) {
                     loadingDialog = LoadingDialog()

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/walk/WalkFragment.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/walk/WalkFragment.kt
@@ -300,7 +300,7 @@ class WalkFragment : Fragment() {
     }
 
     private fun initViewModel() {
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             walkViewModel.walkUiState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest {
                     if(it.isLoading) {
@@ -319,14 +319,14 @@ class WalkFragment : Fragment() {
                 }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             walkViewModel.dogSelectionState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest {
                     walkDogAdapter.submitList(it.dogList)
                 }
         }
 
-        viewLifecycleOwner.lifecycleScope.launch {
+        lifecycleScope.launch {
             walkViewModel.walkEvent.flowWithLifecycle(viewLifecycleOwner.lifecycle)
                 .collectLatest { event ->
                     when(event) {


### PR DESCRIPTION
- lifecycleScope를 사용하도록 일괄 변경(View가 파괴되어도 코루틴 자체는 유지하기 위함)
- 몇 부분은 변경이 불필요 해 보이나, 통일성 위해 변경

resolved: #217 