### PR TITLE
EditText 외부 눌렀을 때 소프트 키보드 숨김처리

### DIFF
--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/shared/KeyboardCleaner.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/shared/KeyboardCleaner.kt
@@ -1,0 +1,46 @@
+package com.nbcfinalteam2.ddaraogae.presentation.shared
+
+import android.app.Activity
+import android.graphics.Rect
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+
+class KeyboardCleaner(private val activity: Activity) {
+    private var prevFocus: View? = null
+    private val gestureDetector = GestureDetector(activity, SingleTapListener())
+
+    fun setPrevFocus(view: View?) {
+        prevFocus = view
+    }
+
+    fun handleTouchEvent(ev: MotionEvent) {
+        gestureDetector.onTouchEvent(ev)
+    }
+
+    private inner class SingleTapListener : GestureDetector.SimpleOnGestureListener() {
+        override fun onSingleTapUp(e: MotionEvent): Boolean {
+            if (e.action == MotionEvent.ACTION_UP && prevFocus is EditText) {
+                val prevFocus = prevFocus ?: return false
+                val hitRect = Rect()
+                prevFocus.getGlobalVisibleRect(hitRect)
+
+                if (!hitRect.contains(e.x.toInt(), e.y.toInt())) {
+                    if (activity.currentFocus is EditText && activity.currentFocus != prevFocus) {
+                        return false
+                    } else {
+                        (activity.getSystemService(AppCompatActivity.INPUT_METHOD_SERVICE) as InputMethodManager).hideSoftInputFromWindow(
+                            prevFocus.windowToken,
+                            0
+                        )
+                        prevFocus.clearFocus()
+                    }
+                }
+            }
+            return super.onSingleTapUp(e)
+        }
+    }
+}

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/add/AddActivity.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/add/AddActivity.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.view.MotionEvent
 import android.view.View
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
@@ -22,6 +23,7 @@ import com.nbcfinalteam2.ddaraogae.databinding.ActivityAddBinding
 import com.nbcfinalteam2.ddaraogae.domain.bus.ItemChangedEventBus
 import com.nbcfinalteam2.ddaraogae.presentation.model.DefaultEvent
 import com.nbcfinalteam2.ddaraogae.presentation.model.DogInfo
+import com.nbcfinalteam2.ddaraogae.presentation.shared.KeyboardCleaner
 import com.nbcfinalteam2.ddaraogae.presentation.ui.loading.LoadingDialog
 import com.nbcfinalteam2.ddaraogae.presentation.util.ImageConverter.uriToByteArray
 import com.nbcfinalteam2.ddaraogae.presentation.util.ToastMaker
@@ -38,6 +40,10 @@ class AddActivity : AppCompatActivity() {
     @Inject lateinit var itemChangedEventBus: ItemChangedEventBus
 
     private var loadingDialog: LoadingDialog? = null
+
+    private val keyboardCleaner: KeyboardCleaner by lazy {
+        KeyboardCleaner(this)
+    }
 
     private val galleryPermissionLauncher =
         registerForActivityResult(
@@ -166,4 +172,12 @@ class AddActivity : AppCompatActivity() {
             }
         }
     }
+
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        if(ev.action == MotionEvent.ACTION_UP) keyboardCleaner.setPrevFocus(currentFocus)
+        val result = super.dispatchTouchEvent(ev)
+        keyboardCleaner.handleTouchEvent(ev)
+        return result
+    }
+
 }

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/edit/EditPetActivity.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/edit/EditPetActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
+import android.view.MotionEvent
 import android.view.View
 import android.widget.ScrollView
 import android.widget.Toast
@@ -24,6 +25,7 @@ import com.nbcfinalteam2.ddaraogae.databinding.ActivityEditPetBinding
 import com.nbcfinalteam2.ddaraogae.domain.bus.ItemChangedEventBus
 import com.nbcfinalteam2.ddaraogae.presentation.model.DefaultEvent
 import com.nbcfinalteam2.ddaraogae.presentation.model.DogInfo
+import com.nbcfinalteam2.ddaraogae.presentation.shared.KeyboardCleaner
 import com.nbcfinalteam2.ddaraogae.presentation.ui.dog.MyPetActivity
 import com.nbcfinalteam2.ddaraogae.presentation.ui.loading.LoadingDialog
 import com.nbcfinalteam2.ddaraogae.presentation.util.ImageConverter.uriToByteArray
@@ -38,6 +40,10 @@ class EditPetActivity : AppCompatActivity() {
     private lateinit var binding: ActivityEditPetBinding
     private val viewModel: EditPetViewModel by viewModels()
     @Inject lateinit var itemChangedEventBus: ItemChangedEventBus
+
+    private val keyboardCleaner: KeyboardCleaner by lazy {
+        KeyboardCleaner(this)
+    }
 
     private var dogData: DogInfo? = null
     private var loadingDialog: LoadingDialog? = null
@@ -214,6 +220,13 @@ class EditPetActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        if(ev.action == MotionEvent.ACTION_UP) keyboardCleaner.setPrevFocus(currentFocus)
+        val result = super.dispatchTouchEvent(ev)
+        keyboardCleaner.handleTouchEvent(ev)
+        return result
     }
 
     companion object {

--- a/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/nbcfinalteam2/ddaraogae/presentation/ui/login/LoginActivity.kt
@@ -1,16 +1,23 @@
 package com.nbcfinalteam2.ddaraogae.presentation.ui.login
 
 import android.os.Bundle
+import android.view.MotionEvent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.fragment.app.viewModels
 import com.nbcfinalteam2.ddaraogae.R
 import com.nbcfinalteam2.ddaraogae.databinding.ActivityLoginBinding
+import com.nbcfinalteam2.ddaraogae.presentation.shared.KeyboardCleaner
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class LoginActivity : AppCompatActivity() {
+
+    private val keyboardCleaner: KeyboardCleaner by lazy {
+        KeyboardCleaner(this)
+    }
+
     private lateinit var binding:ActivityLoginBinding
     private val viewModel: LoginViewModel by viewModels()
 
@@ -28,5 +35,12 @@ class LoginActivity : AppCompatActivity() {
         supportFragmentManager.beginTransaction()
             .replace(R.id.activity_login, LoginFragment())
             .commit()
+    }
+
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        if(ev.action == MotionEvent.ACTION_UP) keyboardCleaner.setPrevFocus(currentFocus)
+        val result = super.dispatchTouchEvent(ev)
+        keyboardCleaner.handleTouchEvent(ev)
+        return result
     }
 }


### PR DESCRIPTION
- KeyboardCleaner를 만들어 재사용 했습니다
- 같은 문제를 겪은 분의 글을 참조해서 구현했습니다
- 다른 EditText를 눌렀을 때와 스크롤뷰 이용 시에는 소프트 키보드가 내려가지 않도록 대응합니다
- 적용된 곳 AddActivity, EditPetActivity, LoginActivity

resolved: #282 


https://github.com/nbc-final-team2/ddaraogae/assets/104819764/ed508fb0-2b51-44bf-8981-9cd2a2724a50


